### PR TITLE
Add enumeration protection

### DIFF
--- a/alpino-tokenizer/src/lib.rs
+++ b/alpino-tokenizer/src/lib.rs
@@ -1,6 +1,9 @@
 mod ctokenize;
 use ctokenize::{c_tokenize, TokenizeError};
 
+mod preproc;
+use preproc::preprocess;
+
 mod postproc;
 use postproc::post_process;
 
@@ -11,7 +14,8 @@ pub(crate) use util::str_to_tokens;
 ///
 /// The paragraph should be on a single line.
 pub fn tokenize(text: &str) -> Result<Vec<Vec<String>>, TokenizeError> {
-    let tokenized = c_tokenize(text)?;
+    let tokenized = preprocess(text);
+    let tokenized = c_tokenize(&tokenized)?;
     let tokenized = post_process(&tokenized);
     Ok(str_to_tokens(&tokenized))
 }

--- a/alpino-tokenizer/src/preproc.rs
+++ b/alpino-tokenizer/src/preproc.rs
@@ -1,0 +1,64 @@
+use std::borrow::Cow;
+
+use lazy_static::lazy_static;
+use regex::Regex;
+
+// This function rewrites enumerations of the form
+//
+// 1. foo, 2. bar en 3. baz
+//
+// to
+//
+// 1# foo, 2# bar en 3# baz
+fn add_enumeration_markers(text: &str) -> Cow<str> {
+    lazy_static! {
+        static ref RE: Regex = Regex::new("(\\s?1)[.](\\s.*?\\W2[.])").unwrap();
+    }
+
+    let mut text = RE.replace_all(text, "$1#$2");
+
+    if let text @ Cow::Borrowed(_) = text {
+        return text;
+    }
+
+    let mut prev = 1;
+    let mut next = 2;
+
+    loop {
+        let next_expr = Regex::new(&format!("({}#\\s.*?\\W{})[.](\\s)", prev, next))
+            .expect("Invalid enumeration expression.");
+        let text_after = next_expr.replace_all(&text, "$1#$2");
+
+        if let Cow::Borrowed(_) = text_after {
+            break;
+        }
+
+        text = Cow::Owned(text_after.into_owned());
+        prev += 1;
+        next += 1;
+    }
+
+    text
+}
+
+pub fn preprocess(text: &str) -> Cow<str> {
+    add_enumeration_markers(text)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::preprocess;
+
+    #[test]
+    fn test_add_enumeration_markers() {
+        assert_eq!(
+            preprocess("1. boter, 2. kaas en 3. eieren"),
+            "1# boter, 2# kaas en 3# eieren"
+        );
+
+        assert_eq!(
+            preprocess("1. boter, 2. kaas en 3. eieren, 1. foo en 2. bar"),
+            "1# boter, 2# kaas en 3# eieren, 1# foo en 2# bar"
+        );
+    }
+}


### PR DESCRIPTION
The tokenizer can get confused by enumeration such as

1. boter, 2. kaas en 3. eieren

So, following the Alpino tokenizer by the letter, we replace the
periods in such enumerations by pound as a special marker:

1# boter, 2# kaas en 3# eieren

Then after tokenization, the markers are replaced by periods. To
restore the original enumerations.