### PR TITLE
Improve error handling

### DIFF
--- a/alpino-tokenizer/src/ctokenize.rs
+++ b/alpino-tokenizer/src/ctokenize.rs
@@ -1,13 +1,18 @@
+use std::error::Error;
+use std::fmt;
 use std::mem;
 use std::os::raw::c_void;
 use std::ptr;
 
 use widestring::WideCString;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TokenizeError {
     /// Could not allocate memory for tokenization output.
     AllocationError,
+
+    /// The input contains the NUL character.
+    InputContainsNul,
 
     /// The transducer returned a non-terminated string.
     NoStringTerminator,
@@ -15,6 +20,25 @@ pub enum TokenizeError {
     /// The string is not in the input language of the transducer.
     NotInInputLanguage,
 }
+
+impl fmt::Display for TokenizeError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        use TokenizeError::*;
+        match self {
+            AllocationError => write!(f, "could not allocate memory for output string")?,
+            InputContainsNul => write!(f, "the input string contained a NUL character")?,
+            NoStringTerminator => write!(f, "the transducer returned a non-terminated string")?,
+            NotInInputLanguage => write!(
+                f,
+                "the input string is not in the input language of the transducer"
+            )?,
+        }
+
+        Ok(())
+    }
+}
+
+impl Error for TokenizeError {}
 
 /// A small pointer wrapper that frees when it goes out of scope.
 struct PtrBox<T> {
@@ -40,7 +64,10 @@ impl<T> Drop for PtrBox<T> {
 }
 
 pub fn c_tokenize(text: &str) -> Result<String, TokenizeError> {
-    let input = WideCString::from_str(text).unwrap();
+    let input = match WideCString::from_str(text) {
+        Ok(input) => input,
+        Err(_) => return Err(TokenizeError::InputContainsNul),
+    };
 
     let mut output_len = input.len() * 2;
     let mut output = PtrBox::alloc_array(output_len);
@@ -66,13 +93,21 @@ pub fn c_tokenize(text: &str) -> Result<String, TokenizeError> {
 
 #[cfg(test)]
 mod tests {
-    use super::c_tokenize;
+    use super::{c_tokenize, TokenizeError};
 
     #[test]
     fn test_c_tokenize() {
         assert_eq!(
             c_tokenize("Dit is een zin. En dit is nog een zin.").unwrap(),
             "Dit is een zin .\nEn dit is nog een zin ."
+        );
+    }
+
+    #[test]
+    fn test_handle_nul_in_input() {
+        assert_eq!(
+            c_tokenize("Deze string bevat een NUL karakter\0"),
+            Err(TokenizeError::InputContainsNul)
         );
     }
 }


### PR DESCRIPTION
- Return an error rather than panicking when the input contains the
  NUL character.
- Implement the Display and Error traits on TokenizeError.