### PR TITLE
Move from CoNLL-X to CoNLL-U

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ version = "0.1.0"
 dependencies = [
  "alpino-tokenizer 0.1.0",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "conllu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "stdinout 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -107,8 +107,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "conllx"
-version = "0.12.1"
+name = "conllu"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -316,7 +316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cc 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "4fc9a35e1f4290eb9e5fc54ba6cf40671ed2a2514c3eeb2b2a908dda2ea5a1be"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
-"checksum conllx 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c38ec5642ce1b214866b917b82093a0fe9c75503dc005763737873aa4cfa4a94"
+"checksum conllu 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "815a564ad2473ee7a159027b9b36a81e6b1abf51f94fd576560f85ce203bd3a1"
 "checksum either 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
 "checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"

--- a/alpino-tokenize/Cargo.toml
+++ b/alpino-tokenize/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 [dependencies]
 alpino-tokenizer = { path = "../alpino-tokenizer", version = "0.1.0" }
 clap = "2"
-conllx = "0.12"
+conllu = "0.3"
 lazy_static = "1"
 regex = "1"
 stdinout = "0.4"

--- a/alpino-tokenize/src/main.rs
+++ b/alpino-tokenize/src/main.rs
@@ -14,7 +14,7 @@ static DEFAULT_CLAP_SETTINGS: &[AppSettings] = &[
 ];
 
 fn main() {
-    let apps = vec![conll::ConllxApp::app()];
+    let apps = vec![conll::ConlluApp::app()];
 
     let cli = App::new("finalfusion")
         .settings(DEFAULT_CLAP_SETTINGS)
@@ -37,7 +37,7 @@ fn main() {
             write_completion_script(cli, shell.parse::<Shell>().unwrap());
         }
 
-        "conllx" => conll::ConllxApp::parse(matches.subcommand_matches("conllx").unwrap()).run(),
+        "conllu" => conll::ConlluApp::parse(matches.subcommand_matches("conllu").unwrap()).run(),
         _unknown => unreachable!(),
     }
 }


### PR DESCRIPTION
- Switch from the conllx to the conllu crate.
- Place the sentence identifier (doc + paragraph + sent) in the
  `sent_id` comment.
- Wikipedia: place the page title in the `title` comment.