### PR TITLE
Add the Tokenizer trait to abstract over tokenizers

### DIFF
--- a/alpino-tokenize/src/conll.rs
+++ b/alpino-tokenize/src/conll.rs
@@ -1,7 +1,7 @@
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter};
 
-use alpino_tokenizer::Tokenizer;
+use alpino_tokenizer::{AlpinoTokenizer, Tokenizer};
 use clap::{App, Arg, ArgMatches};
 use conllu::graph::{Comment, Sentence};
 use conllu::io::{WriteSentence, Writer};
@@ -38,7 +38,7 @@ pub struct ConlluApp {
 impl ConlluApp {
     fn tokenize_para(
         &self,
-        tokenizer: &Tokenizer,
+        tokenizer: &AlpinoTokenizer,
         lines: &[String],
         writer: &mut impl WriteSentence,
         doc_id: Option<&String>,
@@ -134,7 +134,8 @@ impl TokenizeApp for ConlluApp {
             File::open(&self.protobuf_filename)
                 .or_exit("Cannot open tokenizer protobuf definition", 1),
         );
-        let tokenizer = Tokenizer::from_buf_read(protobuf).or_exit("Cannot load tokenizer", 1);
+        let tokenizer =
+            AlpinoTokenizer::from_buf_read(protobuf).or_exit("Cannot load tokenizer", 1);
 
         let input = Input::from(self.input_filename.as_ref());
         let reader = input.buf_read().or_exit("Cannot open input", 1);

--- a/alpino-tokenizer/src/alpino.rs
+++ b/alpino-tokenizer/src/alpino.rs
@@ -1,0 +1,55 @@
+use std::io::BufRead;
+
+use crate::postproc::postprocess;
+use crate::preproc::preprocess;
+
+use crate::tokenizer::Tokenizer;
+use crate::util::str_to_tokens;
+use crate::{FiniteStateTokenizer, TokenizerError};
+
+/// Alpino tokenizer and sentence splitter.
+pub struct AlpinoTokenizer {
+    inner: FiniteStateTokenizer,
+}
+
+impl AlpinoTokenizer {
+    pub fn from_buf_read<R>(read: R) -> Result<Self, TokenizerError>
+    where
+        R: BufRead,
+    {
+        Ok(AlpinoTokenizer {
+            inner: FiniteStateTokenizer::from_buf_read(read)?,
+        })
+    }
+}
+
+impl Tokenizer for AlpinoTokenizer {
+    fn tokenize(&self, text: &str) -> Option<Vec<Vec<String>>> {
+        let tokenized = preprocess(text);
+        let tokenized = self.inner.tokenize_raw(tokenized.chars())?;
+        let tokenized = postprocess(&tokenized);
+        Some(str_to_tokens(&tokenized))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    use super::AlpinoTokenizer;
+    use crate::util::str_to_tokens;
+    use crate::Tokenizer;
+
+    #[test]
+    fn test_tokenize() {
+        let read = BufReader::new(File::open("testdata/toy.proto").unwrap());
+        let tokenizer = AlpinoTokenizer::from_buf_read(read).unwrap();
+        assert_eq!(
+            tokenizer
+                .tokenize("Dit is een zin. En dit is nog een zin...")
+                .unwrap(),
+            str_to_tokens("Dit is een zin .\nEn dit is nog een zin ...")
+        );
+    }
+}

--- a/alpino-tokenizer/src/fst.rs
+++ b/alpino-tokenizer/src/fst.rs
@@ -1,0 +1,88 @@
+use std::collections::HashSet;
+use std::io::BufRead;
+
+use crate::proto::Transducer;
+use crate::tokenizer::Tokenizer;
+use crate::util::str_to_tokens;
+use crate::TokenizerError;
+
+/// Finite state tokenizer and sentence splitter.
+///
+/// This type implements a tokenizer based on a finite-state transducer. In
+/// principle, it should work with any tokenizing transducer built with the
+/// [FSA utilities](https://www.let.rug.nl/~vannoord/Fsa/).
+///
+/// If Alpino's transducer is used for tokenization, it is strongly recommended
+/// to use the `AlpinoTokenizer` data type. `AlpinoTokenizer` applies pre- and
+/// post-processing steps that are expected by Alpino's transducer.
+pub struct FiniteStateTokenizer {
+    known_symbols: HashSet<u32>,
+    transducer: Transducer,
+}
+
+impl FiniteStateTokenizer {
+    pub fn from_buf_read<R>(mut read: R) -> Result<Self, TokenizerError>
+    where
+        R: BufRead,
+    {
+        let mut data = Vec::new();
+        read.read_to_end(&mut data)?;
+
+        let transducer: Transducer = prost::Message::decode(&*data)?;
+        let known_symbols = transducer.transitions.iter().map(|t| t.symbol).collect();
+
+        Ok(FiniteStateTokenizer {
+            known_symbols,
+            transducer,
+        })
+    }
+
+    pub(crate) fn tokenize_raw<I>(&self, chars: I) -> Option<String>
+    where
+        I: IntoIterator<Item = char>,
+    {
+        let mut output = String::new();
+
+        let mut trans_offset = 1;
+        let mut transition = &self.transducer.transitions[trans_offset];
+        for ch in chars {
+            trans_offset = transition.next as usize;
+            transition = &self.transducer.transitions[trans_offset];
+            let symbol = ch as u32;
+
+            if transition.symbol != 1 || self.known_symbols.contains(&symbol) {
+                if transition.symbol == 2 && !self.known_symbols.contains(&symbol) {
+                    output.extend(transition.output.chars().map(|out_ch| {
+                        if out_ch == char::from(2) {
+                            ch
+                        } else {
+                            out_ch
+                        }
+                    }))
+                } else {
+                    while !transition.is_last_of_state && symbol > transition.symbol {
+                        trans_offset += 1;
+                        transition = &self.transducer.transitions[trans_offset];
+                    }
+
+                    if transition.symbol != symbol {
+                        return None;
+                    } else {
+                        output.push_str(&transition.output);
+                    }
+                }
+            }
+        }
+
+        output.push_str(&transition.final_output);
+
+        Some(output)
+    }
+}
+
+impl Tokenizer for FiniteStateTokenizer {
+    fn tokenize(&self, text: &str) -> Option<Vec<Vec<String>>> {
+        let tokenized = self.tokenize_raw(text.chars())?;
+        Some(str_to_tokens(&tokenized))
+    }
+}

--- a/alpino-tokenizer/src/lib.rs
+++ b/alpino-tokenizer/src/lib.rs
@@ -13,16 +13,22 @@
 //! use std::fs::File;
 //! use std::io::BufReader;
 //!
-//! use alpino_tokenizer::Tokenizer;
+//! use alpino_tokenizer::{AlpinoTokenizer, Tokenizer};
 //!
 //! let read = BufReader::new(File::open("testdata/toy.proto").unwrap());
-//! let tokenizer = Tokenizer::from_buf_read(read).unwrap();
+//! let tokenizer = AlpinoTokenizer::from_buf_read(read).unwrap();
 //!
 //! assert_eq!(
 //!   tokenizer.tokenize("Groningen is een Hanzestad. Groningen heeft veel bezienswaardigheden.").unwrap(),
 //!   vec![vec!["Groningen", "is", "een", "Hanzestad", "."],
 //!        vec!["Groningen", "heeft", "veel", "bezienswaardigheden", "."]]);
 //! ```
+
+mod alpino;
+pub use alpino::AlpinoTokenizer;
+
+mod fst;
+pub use fst::FiniteStateTokenizer;
 
 mod proto;
 
@@ -31,6 +37,6 @@ mod preproc;
 mod postproc;
 
 mod tokenizer;
-pub use tokenizer::Tokenizer;
+pub use tokenizer::{Tokenizer, TokenizerError};
 
 mod util;

--- a/alpino-tokenizer/src/tokenizer.rs
+++ b/alpino-tokenizer/src/tokenizer.rs
@@ -1,13 +1,8 @@
-use std::collections::HashSet;
-use std::io::{self, BufRead};
+use std::io;
 
 use thiserror::Error;
 
-use crate::postproc::postprocess;
-use crate::preproc::preprocess;
-use crate::proto::Transducer;
-use crate::util::str_to_tokens;
-
+/// Tokenizer errors.
 #[derive(Debug, Error)]
 pub enum TokenizerError {
     #[error("Cannot read tokenizer protobuf: {0}")]
@@ -17,98 +12,10 @@ pub enum TokenizerError {
     ProtobufDecodeError(#[from] prost::DecodeError),
 }
 
-pub struct Tokenizer {
-    known_symbols: HashSet<u32>,
-    transducer: Transducer,
-}
-
-impl Tokenizer {
-    pub fn from_buf_read<R>(mut read: R) -> Result<Self, TokenizerError>
-    where
-        R: BufRead,
-    {
-        let mut data = Vec::new();
-        read.read_to_end(&mut data)?;
-
-        let transducer: Transducer = prost::Message::decode(&*data)?;
-        let known_symbols = transducer.transitions.iter().map(|t| t.symbol).collect();
-
-        Ok(Tokenizer {
-            known_symbols,
-            transducer,
-        })
-    }
-
-    /// Sentence split and tokenize a paragraph of text.
+/// Tokenizer trait type.
+pub trait Tokenizer {
+    /// Sentence-split and tokenize a paragraph of text.
     ///
     /// The paragraph should be on a single line.
-    pub fn tokenize(&self, text: &str) -> Option<Vec<Vec<String>>> {
-        let tokenized = preprocess(text);
-        let tokenized = self.tokenize_raw(tokenized.chars())?;
-        let tokenized = postprocess(&tokenized);
-        Some(str_to_tokens(&tokenized))
-    }
-
-    pub fn tokenize_raw<I>(&self, chars: I) -> Option<String>
-    where
-        I: IntoIterator<Item = char>,
-    {
-        let mut output = String::new();
-
-        let mut trans_offset = 1;
-        let mut transition = &self.transducer.transitions[trans_offset];
-        for ch in chars {
-            trans_offset = transition.next as usize;
-            transition = &self.transducer.transitions[trans_offset];
-            let symbol = ch as u32;
-
-            if transition.symbol != 1 || self.known_symbols.contains(&symbol) {
-                if transition.symbol == 2 && !self.known_symbols.contains(&symbol) {
-                    output.extend(transition.output.chars().map(|out_ch| {
-                        if out_ch == char::from(2) {
-                            ch
-                        } else {
-                            out_ch
-                        }
-                    }))
-                } else {
-                    while !transition.is_last_of_state && symbol > transition.symbol {
-                        trans_offset += 1;
-                        transition = &self.transducer.transitions[trans_offset];
-                    }
-
-                    if transition.symbol != symbol {
-                        return None;
-                    } else {
-                        output.push_str(&transition.output);
-                    }
-                }
-            }
-        }
-
-        output.push_str(&transition.final_output);
-
-        Some(output)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs::File;
-    use std::io::BufReader;
-
-    use super::Tokenizer;
-    use crate::util::str_to_tokens;
-
-    #[test]
-    fn test_tokenize() {
-        let read = BufReader::new(File::open("testdata/toy.proto").unwrap());
-        let tokenizer = Tokenizer::from_buf_read(read).unwrap();
-        assert_eq!(
-            tokenizer
-                .tokenize("Dit is een zin. En dit is nog een zin...")
-                .unwrap(),
-            str_to_tokens("Dit is een zin .\nEn dit is nog een zin ...")
-        );
-    }
+    fn tokenize(&self, text: &str) -> Option<Vec<Vec<String>>>;
 }


### PR DESCRIPTION
Also provide two implementations:

1. FiniteStateTokenizer: use a transducer without any pre- or
   postprocessing.
2. AlpinoTokenizer: use a transducer, applying the pre- and
   postprocessing needed for the Alpino tokenizer.