### PR TITLE
conllu subcommand: make the PROTOBUF argument required

### DIFF
--- a/alpino-tokenize/src/conll.rs
+++ b/alpino-tokenize/src/conll.rs
@@ -94,7 +94,12 @@ impl TokenizeApp for ConlluApp {
     fn app() -> App<'static, 'static> {
         App::new("conllu")
             .about("Tokenize input and output as CoNLL-X")
-            .arg(Arg::with_name(PROTOBUF).help("Tokenizer protobuf").index(1))
+            .arg(
+                Arg::with_name(PROTOBUF)
+                    .help("Tokenizer protobuf")
+                    .required(true)
+                    .index(1),
+            )
             .arg(Arg::with_name(INPUT).help("Input corpus").index(2))
             .arg(Arg::with_name(OUTPUT).help("Output CoNLL-X").index(3))
             .arg(


### PR DESCRIPTION
This gives a nice clap error if the argument is missing, rather than
an ugly unwrap panic.